### PR TITLE
[STEP17] 카프카 설치와 Producer, Consumer Test하기

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,12 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 
+	//kafka
+	implementation("org.apache.kafka:kafka_2.13:3.9.0") //카프카 기본
+	implementation("org.springframework.kafka:spring-kafka") //KafkaTemplate 용도
+	implementation("org.apache.kafka:kafka-clients:3.9.0") //producer, customer 만들기용
+
+
 	// Lombok
 	compileOnly("org.projectlombok:lombok")
 	annotationProcessor("org.projectlombok:lombok")
@@ -50,6 +56,8 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-testcontainers")
 	testImplementation("org.testcontainers:junit-jupiter")
 	testImplementation("org.testcontainers:mysql")
+	testImplementation("org.testcontainers:kafka:1.20.4")
+	testImplementation("org.springframework.kafka:spring-kafka-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	//테스트 lombok
 	testCompileOnly("org.projectlombok:lombok")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   mysql:
     image: mysql:8.0
     ports:
-      - "3306:3306"
+      - "3307:3306"
     environment:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_USER=application
@@ -11,7 +11,33 @@ services:
       - MYSQL_DATABASE=hhplus
     volumes:
       - ./data/mysql/:/var/lib/mysql
-
+      - ./src/main/resources/:/docker-entrypoint-initdb.d/
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_TICK_TIME: 2000
+      ZOOKEEPER_INIT_LIMIT: 5
+      ZOOKEEPER_SYNC_LIMIT: 2
+    ports:
+      - "2181:2181"
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    container_name: kafka
+    restart: always
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 networks:
   default:
     driver: bridge

--- a/src/main/java/kr/hhplus/be/server/interfaces/kafka/KafkaConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/kafka/KafkaConsumer.java
@@ -1,0 +1,36 @@
+package kr.hhplus.be.server.interfaces.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+
+
+@Service
+public class KafkaConsumer {
+    private CountDownLatch latch = new CountDownLatch(1); //3초에 한번
+    private final Queue<String> receivedMessageQueue = new LinkedList<>();
+
+    @KafkaListener(topics = "test-topic", groupId = "demo")
+    public void listen(ConsumerRecord<?,?> consumerRecord){
+        String message = consumerRecord.value().toString();
+
+        receivedMessageQueue.offer(message);
+        System.out.println("Received message: " + message);
+        latch.countDown();
+    }
+
+
+
+    public Queue<String> getReceivedMessages() throws InterruptedException{
+        latch.await();
+        return receivedMessageQueue;
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/kafka/KafkaProducer.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/kafka/KafkaProducer.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.interfaces.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class KafkaProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void sendMassage(String topic, Object message){
+        kafkaTemplate.send(topic,message);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,15 +12,27 @@ spring:
       max-lifetime: 60000
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
+  #  defer-datasource-initialization: true #data.sql 설정
     open-in-view: false
     generate-ddl: false
-    show-sql: false
+    show-sql: true
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
     properties:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC
-
+  #sql.init.mode: always # data.sql 설정
+  kafka:
+    bootstrap-servers: "localhost:9092"
+    producer:
+      key-serializer: "org.apache.kafka.common.serialization.StringSerializer"
+      value-serializer: "org.springframework.kafka.support.serializer.JsonSerializer"
+    consumer:
+      group-id: "demo"
+      auto-offset-reset: earliest
+      key-deserializer: "org.apache.kafka.common.serialization.StringDeserializer"
+      value-serializer: "org.springframework.kafka.support.serializer.ByteArrayDeserializer"
+      properties.spring.json.trusted.packages: "com.testcontainers.demo"
 ---
 spring.config.activate.on-profile: local, test
 

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
@@ -6,12 +6,16 @@ import org.springframework.boot.testcontainers.service.connection.ServiceConnect
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Configuration
 class TestcontainersConfiguration {
 
 	public static final MySQLContainer<?> MYSQL_CONTAINER;
+	//public static final KafkaContainer KAFKA_CONTAINER;
+	public static final ConfluentKafkaContainer KAFKA_CONTAINER;
 
 	static {
 		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
@@ -23,12 +27,24 @@ class TestcontainersConfiguration {
 		System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
 		System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
 		System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
+
+		//kafka
+		// 네이티브
+		// KAFKA_CONTAINER = new KafkaContainer(DockerImageName.parse("apache/kafka-native:3.8.0"));
+		// 컨플루언트
+		KAFKA_CONTAINER = new ConfluentKafkaContainer("confluentinc/cp-kafka:7.4.0");
+
+		KAFKA_CONTAINER.start();
+		System.setProperty("spring.kafka.bootstrap-servers", KAFKA_CONTAINER.getBootstrapServers());
 	}
 
 	@PreDestroy
 	public void preDestroy() {
 		if (MYSQL_CONTAINER.isRunning()) {
 			MYSQL_CONTAINER.stop();
+		}
+		if (KAFKA_CONTAINER.isRunning()) {
+			KAFKA_CONTAINER.stop();
 		}
 	}
 }

--- a/src/test/java/kr/hhplus/be/server/interfaces/kafka/KafkaProducerConsumerIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/kafka/KafkaProducerConsumerIntegrationTest.java
@@ -1,0 +1,66 @@
+package kr.hhplus.be.server.interfaces.kafka;
+
+import jakarta.transaction.Transactional;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest
+@Testcontainers
+@Transactional
+class KafkaProducerConsumerIntegrationTest {
+
+    @Autowired
+    KafkaProducer kafkaProducer;
+
+    @Autowired
+    KafkaConsumer kafkaConsumer;
+
+
+@DisplayName("[성공]KafkaProducer(Topic)에서 전송한 메시지(String)를 KafkaConsumer에서 받아 출력한다.")
+@Test
+void getMessageReceivedToConsumerFromProducerList() throws InterruptedException {
+    //given
+    String topic = "test-topic";
+    List<String> messages = List.of("1번째 메시지", "2번째 메시지", "3번째 메시지", "4번째 메시지");
+
+    //when
+    for (String message : messages) {
+        kafkaProducer.sendMassage(topic, message);
+    }
+
+    // then
+    Awaitility.await()
+            .pollInterval(Duration.ofMillis(300)) // 300ms마다 체크
+            .atMost(4, TimeUnit.SECONDS) // 최대 10초 대기
+            .untilAsserted(() -> {
+
+                Queue<String> queue = kafkaConsumer.getReceivedMessages();
+
+                List<String> receivedMessages = new ArrayList<>();
+                for (String msg : queue) {
+                    receivedMessages.add(msg.replaceAll("^\"|\"$", ""));
+                }
+
+                Assertions.assertThat(receivedMessages)
+                        .containsExactlyElementsOf(messages);
+            });
+    }
+}


### PR DESCRIPTION
## PR 설명
- docker 를 이용해 kafka 를 설치 및 실행하고 애플리케이션과 연결 설정 - 0f4a6193ae86da5aab5ab4c9b39f31e55c57b144
- 카프카 consumer, producer 를 연동 및 테스트 - 021cdef105ac0d0518b6ae6be56efe62cab22ea3
- (Optional) 카프카 학습 내용 정리 - [spring boot에 아파치 kafka 설정하고 Testcontainers로 Test하기](https://c-turtle-makes-program.tistory.com/15)

## 리뷰 포인트

Awaitiliy await()을 통해 테스트 하는 코드에서 궁금증이 생겼습니다. 비동기로 Consumer에 들어오는 메시지를 순차처리 하기 위해 KafkaConsumer파일의 Listen 에 들어오는 메세지를 Queue로 저장해서 getMessage로 반환하여 순차처리가 되는지와 간단한 메시지가 정확히 일치하는지를 테스트하였습니다.

1.  이렇게 Queue에 메시지를 저장하여 하는 테스트가 올바르게 테스트하는 방법인지 궁금합니다.
2.  1.의 방식이 괜찮다면(혹은 아니더라도) 어떤 걸 추가로 테스트해보면 좋을까요

## Definition of Done (DoD)

    - [v] "도커"를 사용해서 카프카를 설치 및 실행 애플리케이션과 연결
    - [v] 카프카 Producer와 Consumer 구현 후 연동 및 테스트
    - [v] 카프카 학습 내용 정리
